### PR TITLE
Update documentation URL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,4 +34,4 @@ then passing your application object back to the extension, like this:
 
 ## Documentation
 
-The Sphinx-compiled documentation is available here: http://packages.python.org/Flask-SeaSurf/
+The Sphinx-compiled documentation is available here: http://flask-seasurf.readthedocs.io/


### PR DESCRIPTION
Fixed the main docs URL so a redirect is no longer necessary.